### PR TITLE
Add proxy flag

### DIFF
--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -43,6 +43,7 @@ token: sdfj-2131023-dslfjsd-12321
 zone: mydomain.com
 domains:
   - test.mydomain.com
+proxy: false
 seconds: 300
 ```
 
@@ -80,6 +81,10 @@ The Zone Name for your domain on Cloudflare.
 ### Option: `domains`
 
 A list of domains to be added or updated in your zone. An acceptable naming convention is `test.mydomain.com`.
+
+### Option: `proxy`
+
+Enables [Cloudflare Edge Proxy](https://support.cloudflare.com/hc/en-us/articles/205177068) for your domains. Optional, defaults to `false`.
 
 ### Option: `seconds`
 

--- a/cloudflare/cloudflare_api.sh
+++ b/cloudflare/cloudflare_api.sh
@@ -3,6 +3,7 @@
 TOKEN=$(bashio::config 'token')
 ZONE=$(bashio::config 'zone')
 DOMAINS=$(bashio::config 'domains')
+PROXY=$(bashio::config 'proxy')
 
 bashio::log.info "Zone: $ZONE"
 
@@ -33,7 +34,7 @@ function create_a_record() {
 	curl -sX POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" \
 		-H "Authorization: Bearer $TOKEN" \
 		-H "Content-Type: application/json" \
-		--data '{"type":"A","name":"'$domain'","content":"'$ip'","proxied":false}' -o /dev/null
+		--data '{"type":"A","name":"'$domain'","content":"'$ip'","proxied":'$PROXY'}' -o /dev/null
 
 	bashio::log.info "Created A Record - $domain"
 }
@@ -45,7 +46,7 @@ function update_a_record() {
 	curl -sX PUT "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/$a_record" \
 		-H "Authorization: Bearer $TOKEN" \
 		-H "Content-Type: application/json" \
-		--data '{"type":"A","name":"'$domain'","content":"'$ip'","proxied":false}' -o /dev/null
+		--data '{"type":"A","name":"'$domain'","content":"'$ip'","proxied":'$PROXY'}' -o /dev/null
 		
 	bashio::log.info "Updated A Record - $domain"
 }

--- a/cloudflare/config.json
+++ b/cloudflare/config.json
@@ -17,6 +17,7 @@
     "token": null,
     "zone": null,
     "domains": [ null ],
+    "proxy": false,
     "seconds": 300
   },
   "schema": {
@@ -28,6 +29,7 @@
     "token": "str",
     "zone": "str",
     "domains": [ "str" ],
+    "proxy": "bool?",
     "seconds": "int"
   }
 }


### PR DESCRIPTION
Allow use of Cloudflare's proxy feature by introducing a new flag in
config.json.

----

First of all, thank you for creating this HA add-on - it works very well for me.
As Cloudflare offers proxying requests I thought it would be useful to expose this option in the add-on as well. 